### PR TITLE
Upgrade React peer dependency to React 18

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "uppercamelcase": "^3.0.0"
   },
   "peerDependencies": {
-    "react": "^16.8.6 || ^17"
+    "react": "^16.8.6 || ^17 || ^18"
   },
   "dependencies": {
     "prop-types": "^15.7.2"


### PR DESCRIPTION
This would solve the installation error:

```
npm ERR! Could not resolve dependency:
npm ERR! peer react@"^16.8.6 || ^17" from react-bootstrap-icons@1.8.1
npm ERR! node_modules/react-bootstrap-icons
npm ERR!   react-bootstrap-icons@"^1.8.1" from the root project
```