### PR TITLE
Updated README

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ Other ways to use Boostrap icons: [https://icons.getbootstrap.com/#usage](https:
 ## License
 
 - react-bootstrap-icons are open sourced ([MIT](https://github.com/ismamz/react-bootstrap-icons/blob/master/LICENSE.md))
-- Bootstrap Icons are open-sourced ([MIT](https://github.com/twbs/icons/blob/main/LICENSE.md)](https://github.com/twbs/icons/blob/main/LICENSE.md)).
+- Bootstrap Icons are open-sourced ([MIT](https://github.com/twbs/icons/blob/main/LICENSE.md)).
 
 ## Collaborators
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ The brand new [Bootstrap Icons library](https://icons.getbootstrap.com/) to use 
 
 > Currently v1.9.1, over **1600 icons!**
 
-<img src="https://api.framer.com/store/assets/ismael/bootstrap-icons/artwork.png?ODhmNDI">
+![bootstrap-icons](https://user-images.githubusercontent.com/39626451/192898250-711e2281-ab03-433a-afeb-4ad542b68a5b.png)
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Icons can be configured with inline props:
 <ArrowRight color="royalblue" size={96} />
 ```
 
-You can pass wathever props you want:
+You can pass whatever props you want:
 
 ```jsx
 <ArrowRight className="ml-4" />
@@ -54,9 +54,41 @@ export default function App() => {
 
 The icon names are the `PascalCase` version of the original name. For those icons whose name begins with a number, the `Icon` prefix will be used. Examples: `arrow-right` → `ArrowRight`, `1-circle` → `Icon1Circle`.
 
+You can also create an "Icon" component and pass it the icon name as a prop:
+
+```jsx
+import * as icons from 'react-bootstrap-icons';
+
+interface IconProps extends icons.IconProps {
+  // Cannot use "name" as it is a valid SVG attribute
+  // "iconName", "filename", "icon"... will do it instead
+  iconName: keyof typeof icons;
+}
+
+export const Icon = ({iconName, ...props}: IconProps) => {
+  const BootstrapIcon = icons[iconName];
+  return <BootstrapIcon {...props} />;
+}
+```
+
+```jsx
+import { Icon } from './Icon';
+...
+<Icon iconName="Stopwatch" color="royalblue" size={96} className="align-top" />
+...
+```
+
+## IconProps
+
+|Name|Type|Description|
+|---|---|---|
+|color?|string|color of the icon|
+|size?|string \| number |size of the icon|
+|title?|string|acts kind of like img alt="" and/or div title=""|
+
 ## Figma Plugin
 
-You can install it from Figma app: [Bootstrap Icons Plugin for Figma](https://www.figma.com/community/plugin/868341386266170307/Bootstrap-Icons)
+You can install it from the Figma app: [Bootstrap Icons Plugin for Figma](https://www.figma.com/community/plugin/868341386266170307/Bootstrap-Icons)
 
 ## More options
 
@@ -65,7 +97,7 @@ Other ways to use Boostrap icons: [https://icons.getbootstrap.com/#usage](https:
 ## License
 
 - react-bootstrap-icons are open sourced ([MIT](https://github.com/ismamz/react-bootstrap-icons/blob/master/LICENSE.md))
-- Bootstrap Icons are open sourced ([MIT](https://github.com/twbs/icons/blob/main/LICENSE.md)).
+- Bootstrap Icons are open-sourced ([MIT](https://github.com/twbs/icons/blob/main/LICENSE.md)](https://github.com/twbs/icons/blob/main/LICENSE.md)).
 
 ## Collaborators
 

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ export default function App() => {
 
 The icon names are the `PascalCase` version of the original name. For those icons whose name begins with a number, the `Icon` prefix will be used. Examples: `arrow-right` → `ArrowRight`, `1-circle` → `Icon1Circle`.
 
-You can also create an "Icon" component and pass it the icon name as a prop:
+You can also create an `Icon` component and pass it the icon name as a prop:
 
 ```jsx
 import * as icons from 'react-bootstrap-icons';
@@ -65,7 +65,7 @@ interface IconProps extends icons.IconProps {
   iconName: keyof typeof icons;
 }
 
-export const Icon = ({iconName, ...props}: IconProps) => {
+export const Icon = ({ iconName, ...props }: IconProps) => {
   const BootstrapIcon = icons[iconName];
   return <BootstrapIcon {...props} />;
 }
@@ -74,17 +74,22 @@ export const Icon = ({iconName, ...props}: IconProps) => {
 ```jsx
 import { Icon } from './Icon';
 ...
-<Icon iconName="Stopwatch" color="royalblue" size={96} className="align-top" />
+<Icon
+  iconName="Stopwatch"
+  color="royalblue"
+  size={96}
+  className="align-top"
+/>
 ...
 ```
 
 ## IconProps
 
-|Name|Type|Description|
-|---|---|---|
-|color?|string|color of the icon|
-|size?|string \| number |size of the icon|
-|title?|string|acts kind of like img alt="" and/or div title=""|
+| Name   | Type             | Description                                      |
+| ------ | ---------------- | ------------------------------------------------ |
+| color? | string           | color of the icon                                |
+| size?  | string \| number | size of the icon                                 |
+| title? | string           | acts kind of like img alt="" and/or div title="" |
 
 ## Figma Plugin
 
@@ -96,7 +101,7 @@ Other ways to use Boostrap icons: [https://icons.getbootstrap.com/#usage](https:
 
 ## License
 
-- react-bootstrap-icons are open sourced ([MIT](https://github.com/ismamz/react-bootstrap-icons/blob/master/LICENSE.md))
+- react-bootstrap-icons are open-sourced ([MIT](https://github.com/ismamz/react-bootstrap-icons/blob/master/LICENSE.md))
 - Bootstrap Icons are open-sourced ([MIT](https://github.com/twbs/icons/blob/main/LICENSE.md)).
 
 ## Collaborators


### PR DESCRIPTION
Interface export from [here](https://github.com/ismamz/react-bootstrap-icons/commit/c43ec0407ee4f49a0dee038eed0cc13427320d19) seems to have been undone in the latest version.

So, I re-added export for Props and updated the README