### PR TITLE
Fix link to Bootstrap Icons license

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ Other ways to use Boostrap icons: [https://icons.getbootstrap.com/#usage](https:
 ## License
 
 - react-bootstrap-icons are open-sourced ([MIT](https://github.com/ismamz/react-bootstrap-icons/blob/master/LICENSE.md))
-- Bootstrap Icons are open-sourced ([MIT](https://github.com/twbs/icons/blob/main/LICENSE.md)).
+- Bootstrap Icons are open-sourced ([MIT](https://github.com/twbs/icons/blob/main/LICENSE)).
 
 ## Collaborators
 


### PR DESCRIPTION
With https://github.com/twbs/icons/commit/a51ba52c238a013dec467173f5c5f7917284363e the license file name was changed from "LICENSE.md" to "LICENSE".